### PR TITLE
Include include/ in roslz4 sdist

### DIFF
--- a/roslz4/MANIFEST.in
+++ b/roslz4/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include ros_comm/utilities/roslz4/include *
 recursive-include ros_comm/utilities/roslz4/src *.h
 recursive-include roscpp_core/cpp_common/include *
+recursive-include include *
 


### PR DESCRIPTION
I couldn't build roslz4 from source since the current sdist package of roslz4 doesn't have `include/` directory. I added `include` to `MANIFEST.in` to fix that problem.