### PR TITLE
Fix cv_bridge conversion error

### DIFF
--- a/cv_bridge/python/cv_bridge/boost/cv_bridge_boost.py
+++ b/cv_bridge/python/cv_bridge/boost/cv_bridge_boost.py
@@ -116,6 +116,9 @@ def CV_MAT_DEPTHWrap(flags):
 
 
 def cvtColor2(img, encoding_in, encoding_out):
+    if encoding_in == encoding_out:
+        return img
+
     conversion = _CV_CONVERSTIONS[(encoding_in, encoding_out)]
     # depth conversion is not yet implemented
     return cv2.cvtColor(img, conversion)


### PR DESCRIPTION
Currently, `cv_bridge.imgmsg_to_cv2` raises an error if the actual encoding of a image message and `desired_encoding` are the same.
I changed `cvtColor2` to return image as is if `encoding_in` is equal to `encoding_out` to handle this case.