### PR TITLE
Use NotImplementedError

### DIFF
--- a/cv_bridge/python/cv_bridge/boost/cv_bridge_boost.py
+++ b/cv_bridge/python/cv_bridge/boost/cv_bridge_boost.py
@@ -104,7 +104,7 @@ def getCvType(encoding):
 
 
 def cvtColorForDisplay():
-    raise NotImplemented("cvtColorForDisplay is not implemented yet")
+    raise NotImplementedError("cvtColorForDisplay is not implemented yet")
 
 
 def CV_MAT_CNWrap(flags):


### PR DESCRIPTION
`NotImplemented` is a special value to represent the operation is not implemented while `NotImplementedError` is an error.
https://docs.python.org/3/library/constants.html#NotImplemented

I think we should use `NotImplementedError` in this case.