### PR TITLE
Add dynamic_reconfigure to packages.yaml

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -129,6 +129,10 @@
 - name: catkin
   repository: ros/catkin
   version: 0.7.18
+- name: dynamic_reconfigure
+  repository: ros/dynamic_reconfigure
+  version: 1.6.0
+  src: src
 # others
 - name: image_geometry
   repository: ros-perception/vision_opencv

--- a/packages.yaml
+++ b/packages.yaml
@@ -133,6 +133,7 @@
   repository: ros/dynamic_reconfigure
   version: 1.6.0
   src: src
+  release_version: 1.6.0.post0  # genpy 0.6.14
 # others
 - name: image_geometry
   repository: ros-perception/vision_opencv


### PR DESCRIPTION
`dynamic_reconfigure` is not listed in `packages.yaml`.
It was removed in the refactoring commit (by mistake, I guess): https://github.com/rospypi/simple/commit/972ee06dbc01b963146c261c43961a9f4409f453

Therefore the current rospy-builder does not generate `dynamic_reconfigure` package.
https://rospypi.github.io/simple/_pre/

`dynamic_reconfigure` exists in `https://rospypi.github.io/simple/` page, but this is no longer updated for the above reason.