### PR TITLE
Make genpy generated files consistent

### DIFF
--- a/PyKDL/setup.py
+++ b/PyKDL/setup.py
@@ -26,7 +26,7 @@ if platform.system() != "Windows":
 setup(
     name="PyKDL",
     packages=["PyKDL"],
-    version="1.5",
+    version="1.5.1",
     ext_package="PyKDL",
     ext_modules=[Extension(
         "PyKDL",

--- a/packages.yaml
+++ b/packages.yaml
@@ -176,7 +176,7 @@
   type: msg
   repository: ros/common_msgs
   version: 1.13.0
-  release_version: 1.13.0.post2  # genpy 0.6.14
+  release_version: 1.13.0.post3  # genpy 0.6.14
   path: actionlib_msgs
 - name: shape_msgs
   type: msg
@@ -194,7 +194,7 @@
   type: msg
   repository: ros/common_msgs
   version: 1.13.0
-  release_version: 1.13.0.post2  # genpy 0.6.14
+  release_version: 1.13.0.post3  # genpy 0.6.14
   path: nav_msgs
 - name: stereo_msgs
   type: msg
@@ -206,25 +206,25 @@
   type: msg
   repository: ros/common_msgs
   version: 1.13.0
-  release_version: 1.13.0.post3  # genpy 0.6.14+
+  release_version: 1.13.0.post4  # genpy 0.6.14+
   path: trajectory_msgs
 - name: visualization_msgs
   type: msg
   repository: ros/common_msgs
   version: 1.13.0
-  release_version: 1.13.0.post3  # genpy 0.6.14+
+  release_version: 1.13.0.post4  # genpy 0.6.14+
   path: visualization_msgs
 - name: tf
   repository: ros/geometry
   version: 1.12.1
-  release_version: 1.12.1.post2  # genpy 0.6.14
+  release_version: 1.12.1.post3  # genpy 0.6.14
   path: tf
   src: src
 - name: tf2_msgs
   type: msg
   repository: ros/geometry2
   version: 0.7.2
-  release_version: 0.7.2.post2  # genpy 0.6.14
+  release_version: 0.7.2.post3  # genpy 0.6.14
   path: tf2_msgs
 - name: tf2_sensor_msgs
   repository: ros/geometry2
@@ -239,7 +239,7 @@
   type: msg
   repository: ros-controls/control_msgs
   version: 1.5.2
-  release_version: 1.5.2.post3  # genpy 0.6.14+
+  release_version: 1.5.2.post4  # genpy 0.6.14+
   path: control_msgs
 - name: map_msgs
   type: msg
@@ -257,5 +257,5 @@
   type: msg
   repository: ros-simulation/gazebo_ros_pkgs
   version: 2.5.20
-  release_version: 2.5.20.post3  # genpy 0.6.14+
+  release_version: 2.5.20.post4  # genpy 0.6.14+
   path: gazebo_msgs

--- a/packages.yaml
+++ b/packages.yaml
@@ -169,7 +169,7 @@
 - name: sensor_msgs
   repository: ros/common_msgs
   version: 1.13.0
-  release_version: 1.13.0.post2  # genpy 0.6.14
+  release_version: 1.13.0.post3  # genpy 0.6.14
   path: sensor_msgs
   src: src
 - name: actionlib_msgs

--- a/rospy-builder/rospy_builder/build.py
+++ b/rospy-builder/rospy_builder/build.py
@@ -286,6 +286,12 @@ def generate_package_from_rosmsg(
     import genpy.generator
     import genpy.genpy_main
 
+    # NOTE: genpy uses a global variable to manage variable names
+    # As such, the variable names may change frequently depending on the
+    # order in which `genpy.generate_messages` is called.
+    # In order to avoid unnecessary changes, call `reset_var` every time.
+    genpy.generator.reset_var()
+
     search_dir = {package: [package_dir / "msg"]}
     if search_root_dir is not None:
         for msg_dir in search_root_dir.glob("**/msg"):
@@ -303,6 +309,9 @@ def generate_package_from_rosmsg(
     for gentype in ("msg", "srv"):
         files = (package_dir / gentype).glob(f"*.{gentype}")
         if files:
+            # NOTE: files needs to be in alphabetical order in order to make
+            # the generated files consistent
+            files = list(sorted(files))
             if gentype == "msg":
                 generator = genpy.generator.MsgGenerator()
             elif gentype == "srv":

--- a/rospy-builder/setup.py
+++ b/rospy-builder/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="rospy-builder",
-    version="0.5.3",
+    version="0.5.4",
     description="rospy package build tool",
     author="Tamamki Nishino",
     author_email="otamachan@gmail.com",


### PR DESCRIPTION
As genpy uses a global variable to manage their variable names in generated files, the variable names may change depending on the order in which the files are processed.

https://github.com/ros/genpy/blob/9c7c7dfd690589df89e3d67e721fc7e12cf5c7a7/src/genpy/generator.py#L374-L378

In order to avoid unnecessary changes, this PR changes `rospy-builder` to
- Call `genpy.generator.reset_var` every time before processing a package
- Sort file names in alphabetical order