### PR TITLE
Update native build workflow to support the latest GitHub actions virtualenv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,12 @@ jobs:
         exclude:
           - platform: macos-latest
             python-version: 3.6
+          - platform: windows-latest
+            python-version: 3.6
         include:
           - platform: macos-10.15
+            python-version: 3.6
+          - platform: windows-2016
             python-version: 3.6
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,9 @@ jobs:
       run: |
         brew install eigen boost
         echo BRANCH_NAME=Darwin_${PYTHON_VERSION} >> $GITHUB_ENV
+    - name: Add msbuild to PATH(Windows)
+      if: startsWith(matrix.platform, 'windows-')
+      uses: microsoft/setup-msbuild@v1.1
     - name: Install packages(Windows)
       if: startsWith(matrix.platform, 'windows-')
       env:
@@ -102,7 +105,7 @@ jobs:
       run: |
         curl -LO -s "https://github.com/lz4/lz4/archive/v1.9.2.zip"
         unzip -q v1.9.2.zip -d roslz4
-        "/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
+        MSBuild "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
         curl -LO -s "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip"
         unzip -q eigen-3.3.7.zip -d PyKDL
         curl -LO -s "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         curl -LO -s "https://github.com/lz4/lz4/archive/v1.9.2.zip"
         unzip -q v1.9.2.zip -d roslz4
-        MSBuild "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
+        msbuild "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
         curl -LO -s "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip"
         unzip -q eigen-3.3.7.zip -d PyKDL
         curl -LO -s "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         curl -LO -s "https://github.com/lz4/lz4/archive/v1.9.2.zip"
         unzip -q v1.9.2.zip -d roslz4
-        msbuild "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
+        msbuild.exe "roslz4\lz4-1.9.2\visual\VS2017\liblz4\liblz4.vcxproj" //t:Build //p:Configuration=Release //p:Platform="x64" //p:ForceImportBeforeCppTargets="D:\a\simple\simple\roslz4\build.props" //p:WindowsTargetPlatformVersion="10.0.19041.0"
         curl -LO -s "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip"
         unzip -q eigen-3.3.7.zip -d PyKDL
         curl -LO -s "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         include:
           - platform: macos-10.15
             python-version: 3.6
-          - platform: windows-2016
+          - platform: windows-2019
             python-version: 3.6
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
       matrix:
         platform: [ubuntu-18.04, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
+        exclude:
+          - platform: macos-latest
+            python-version: 3.6
+        include:
+          - platform: macos-10.15
+            python-version: 3.6
 
     steps:
     - name: Git config


### PR DESCRIPTION
It seems windows-latest and macos-latest are upgraded to windows-2022 and macos-11, respectively.

- windows-2022: https://github.com/actions/virtual-environments/blob/c0d57013e10dfe6a30cfb78f135e7f54f081671d/images/win/Windows2022-Readme.md
- macos-11: https://github.com/actions/virtual-environments/blob/c0d57013e10dfe6a30cfb78f135e7f54f081671d/images/macos/macos-11-Readme.md

As the latest environments dropped Python 3.6 support, I updated the matrix strategy to use older platform versions for Python 3.6.
Also, since the path for `MSBuild.exe` is tightly depends on each platform version, I introduced `microsoft/setup-msbuild` to make the path version agnostic.